### PR TITLE
admin and user authentication for reviews

### DIFF
--- a/app/controllers/api/v1/reviews_controller.rb
+++ b/app/controllers/api/v1/reviews_controller.rb
@@ -1,26 +1,51 @@
 class Api::V1::ReviewsController < ApiController
   protect_from_forgery unless: -> {request.format.json? }
-  before_action :authenticate_user!, except: [:show]
-
-  def show 
-    render json: review.all
-  end
-
+  before_action :authenticate_user
+  before_action :authorize_user, except: [:create]
+  
   def create
     review = Review.new(review_params)
     review.sauce_id = params[:sauce_id]
     review.user_id = current_user[:id]
 
     if review.save
-      render json: {review: review}
+      votes = review.votes
+      payload = {**review.attributes, votes: votes}
+      render json: {review: payload}
     else 
       render json: {error: review.errors.full_messages, status: :unprocessable_entity }
     end
   end
 
+  def destroy
+    review = Review.find(params[:id])
+
+    destroy_review(review)
+  end
+
   private 
+
+  def authenticate_user
+    if !user_signed_in?
+      render json: {error: ["you must be signed in"]}
+    end
+  end
+
+  def authorize_user
+    if !user_signed_in? || !(current_user.id == Review.find(params['id']).user.id) && !(current_user.role == 'admin')
+      render json: {error: ["Only admins have access to this feature"]}
+    end
+  end
 
   def review_params
     params.require(:review).permit(:title, :rating, :heatIndex, :body)
+  end
+
+  def destroy_review(review)
+    if review.destroy
+      render json: Sauce.find(params[:sauce_id])
+    else
+      render json: {error: "Unable to delete this review", status: :not_implemented}
+    end
   end
 end 

--- a/app/controllers/api/v1/sauces_controller.rb
+++ b/app/controllers/api/v1/sauces_controller.rb
@@ -1,5 +1,5 @@
 class Api::V1::SaucesController < ApiController
   def show    
-    render json: Sauce.find(params[:id]), include: "reviews,reviews.votes"
+    render json: Sauce.find(params[:id])
   end 
 end 

--- a/app/javascript/react/components/ReviewForm.js
+++ b/app/javascript/react/components/ReviewForm.js
@@ -1,3 +1,4 @@
+import _ from "lodash"
 import React, { useState } from "react"
 import ErrorDisplay from "./ErrorDisplay"
 
@@ -11,7 +12,6 @@ const ReviewForm = (props) => {
   const [errors, setErrors] = useState({})
 
   const postReview = async (formData) =>{
-    
     try {
       const response = await fetch(`/api/v1/sauces/${props.sauce.id}/reviews`, {
         credentials: "same-origin",
@@ -28,9 +28,11 @@ const ReviewForm = (props) => {
         throw(error)
       }
       const reviewObject = await response.json()
+
       if (reviewObject.review) {
-        setLoginWarning(false)
         appendNewReview(reviewObject.review)
+      } else if (reviewObject.error) {
+        setErrors({'error: ': reviewObject.error})
       }
 
     } catch(error) {
@@ -47,7 +49,7 @@ const ReviewForm = (props) => {
 
   const validForSubmission = () => {
     let submitErrors = {}
-    const requiredFields = ["title", "rating", "heatIndex", "body"]
+    const requiredFields = ["title", "rating", "heatIndex"]
     requiredFields.forEach(field => {
       if (newReview[field].trim() == "") {
         submitErrors = {
@@ -55,9 +57,12 @@ const ReviewForm = (props) => {
           [field]: "cannot be blank"
         }
       }
-      setErrors(submitErrors)
     })
-    return errors
+    if (_.isEmpty(submitErrors)) {
+      return true
+    } 
+    setErrors(submitErrors)
+    return false
   }
 
   const handleFormSubmit = (event) => {

--- a/app/javascript/react/components/ReviewTile.js
+++ b/app/javascript/react/components/ReviewTile.js
@@ -7,7 +7,7 @@ library.add(faArrowUp, faArrowDown);
 
 const ReviewTile = props =>{
   const [selectedButton, setSelectedButton] = useState(null)
-  const [reviewKarma, setReviewKarma] = useState(null)
+  const [reviewKarma, setReviewKarma] = useState(0)
   const [error, setError] = useState(null)
 
   const dateString = new Date(props.createdAt).toDateString()
@@ -80,10 +80,49 @@ const ReviewTile = props =>{
     }
   }
 
+  const deleteReviewFetch = async () => {
+    try {
+      const response = await fetch(`/api/v1/sauces/${props.sauce.id}/reviews/${props.id}`,{
+        credentials: "same-origin",
+        method: "DELETE",
+        headers: {
+          "Accept": "application/json",
+          "Content-Type": "application/json"
+        },
+        body: JSON.stringify({user_id: props.reviewUserId})
+      }) 
+      if (!response.ok) {
+        const errorMessage = `${response.status} (${response.status.text})`
+        const error = new Error(errorMessage)
+        throw(error)
+      }
+      const sauceObject = await response.json()
+      props.setSauce(sauceObject.sauce)
+    } catch (error) {
+      console.log(`Error in fetch: ${error}`)
+    }
+  }
+
+  const deleteReviewClickHandler = (event) => {
+    event.preventDefault()
+    deleteReviewFetch()
+  }
+
+  const reviewDeleteButton = () => {
+    if (props.currentUser.role === 'admin' || props.currentUser.id === props.reviewUserId) {
+      return (
+        <button className="button" onClick={deleteReviewClickHandler}>Delete this review</button>
+      )
+    } 
+  }
+
   return(
     <div className="review-tile callout">
       <div className="">
-        <h3 className="review-tile-title-text">{props.title}</h3>
+        <div className="grid-x align-justify">
+          <h3 className="review-tile-title-text">{props.title}</h3>
+          {reviewDeleteButton()}
+        </div>
         <div className="grid-x" >
           <h5 className="cell small-6 medium-4 review-tile-rating-text" > {`Rating: ${props.rating}/5`}</h5>
           <h5 className="cell small-6 medium-4 review-tile-rating-text" >{`Heat Index: ${props.heatIndex}/10`}</h5>

--- a/app/javascript/react/components/SauceShowPage.js
+++ b/app/javascript/react/components/SauceShowPage.js
@@ -35,6 +35,7 @@ const SauceShowPage = (props) => {
     }
 
     const reviewTiles = sauce.reviews.map((review)=>{
+
       const hasUserVoted = review.votes.filter(vote => vote.user_id === currentUser.id)
       
       let currentUserVote = null
@@ -47,6 +48,7 @@ const SauceShowPage = (props) => {
         <ReviewTile
           key={review.id}
           id={review.id}
+          reviewUserId={review.user_id}
           title={review.title}
           rating={review.rating}
           heatIndex={review.heatIndex}
@@ -54,6 +56,9 @@ const SauceShowPage = (props) => {
           createdAt={review.created_at}
           totalKarma={review.total_karma}
           currentUserVote={currentUserVote}
+          currentUser={currentUser}
+          sauce={sauce}
+          setSauce={setSauce}
         />
       )  
     })

--- a/app/serializers/review_serializer.rb
+++ b/app/serializers/review_serializer.rb
@@ -1,5 +1,5 @@
 class ReviewSerializer < ActiveModel::Serializer
-  attributes :id, :title, :rating, :heatIndex, :body, :created_at, :total_karma
+  attributes :id, :title, :rating, :heatIndex, :body, :created_at, :total_karma, :user_id, :votes
 
   has_many :votes
 end

--- a/app/serializers/vote_serializer.rb
+++ b/app/serializers/vote_serializer.rb
@@ -1,3 +1,3 @@
 class VoteSerializer < ActiveModel::Serializer
-  attributes :id, :vote_type, :user_id
+  attributes :vote_type, :user_id
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do 
       resources :sauces, only: [:show] do 
-        resources :reviews, only: [:show, :create]
+        resources :reviews, only: [:create, :destroy]
       end 
       resources :users, only: [:show]
       resources :votes, only: [:create]

--- a/spec/features/reviews_controller_spec.rb
+++ b/spec/features/reviews_controller_spec.rb
@@ -1,86 +1,78 @@
 require "rails_helper" 
 
 RSpec.describe Api::V1::ReviewsController, type: :controller do
-
-  describe "POST#create" do 
+  context "Testing reviews controller" do 
+    let(:user) { FactoryBot.create(:user) }
+    let(:sauce) { FactoryBot.create(:sauce) }
     
-    it "returns JSON of new review" do 
-      ketchup = FactoryBot.create(:sauce)
-      user = FactoryBot.create(:user)
-      review = FactoryBot.create(:review, sauce: ketchup, user: user)
-
+    before (:each) do
       sign_in user
+    end
 
-      post_json = {
-        title: review.title, 
-        rating: review.rating,
-        heatIndex: review.heatIndex,
-        body: review.body
-      }
-
-      post :create, params: { review: post_json, sauce_id: ketchup.id }, format: :json
-      returned_json = JSON.parse(response.body)
-
-      expect(response.status).to eq 200
-      expect(response.content_type).to eq("application/json")
-      expect(returned_json).to be_kind_of(Hash)
-      expect(returned_json).to_not be_kind_of(Array)
-      expect(returned_json['review']['title']).to eq "Delicious sauce"
-      expect(returned_json['review']['rating']).to eq 5
-      expect(returned_json['review']['heatIndex']).to eq 0
-      expect(returned_json['review']['body']).to eq "it's delicious."
-    end 
+    describe "POST#create" do   
+      it "returns JSON of new review" do 
     
-    it "returns JSON of new review" do 
-      ketchup = FactoryBot.create(:sauce)
-      user = FactoryBot.create(:user)
-      review = FactoryBot.create(:review, sauce: ketchup, user: user)
+        post_json = {
+          title: "Delicious sauce", 
+          rating: 5,
+          heatIndex: 0,
+          body: "it's delicious."
+        }
 
-      sign_in user
+        post :create, params: { review: post_json, sauce_id: sauce.id }, format: :json
+        returned_json = JSON.parse(response.body)
 
-      post_json = {
-        title: review.title, 
-        rating: review.rating,
-        heatIndex: review.heatIndex,
-        body: review.body
-      }
+        expect(response.status).to eq 200
+        expect(response.content_type).to eq("application/json")
+        expect(returned_json).to be_kind_of(Hash)
+        expect(returned_json).to_not be_kind_of(Array)
+        expect(returned_json['review']['title']).to eq "Delicious sauce"
+        expect(returned_json['review']['rating']).to eq 5
+        expect(returned_json['review']['heatIndex']).to eq 0
+        expect(returned_json['review']['body']).to eq "it's delicious."
+      end 
 
-      post :create, params: { review: post_json, sauce_id: ketchup.id }, format: :json
-      returned_json = JSON.parse(response.body)
+      it "Returns an error for invalid input" do
 
-      expect(response.status).to eq 200
-      expect(response.content_type).to eq("application/json")
-      expect(returned_json).to be_kind_of(Hash)
-      expect(returned_json).to_not be_kind_of(Array)
-      expect(returned_json['review']['title']).to eq "Delicious sauce"
-      expect(returned_json['review']['rating']).to eq 5
-      expect(returned_json['review']['heatIndex']).to eq 0
-      expect(returned_json['review']['body']).to eq "it's delicious."
+        post_json = {
+          title: "",
+          rating: "",
+          heatIndex: ""
+        }
+
+        post :create, params: { review: post_json, sauce_id: sauce.id }, format: :json
+        returned_json = JSON.parse(response.body)
+
+        expect(response.content_type).to eq("application/json")
+        expect(returned_json).to be_kind_of(Hash)
+        expect(returned_json).to_not be_kind_of(Array)
+        expect(returned_json['error']).to be_kind_of(Array)
+        expect(returned_json['error'].include?("Title can't be blank")).to eq true 
+        expect(returned_json['error'].include?("Rating is not a number")).to eq true 
+        expect(returned_json['error'].include?("Heatindex is not a number")).to eq true 
+            
+      end
     end 
 
-    it "Returns an error for invalid input" do
-      ketchup = FactoryBot.create(:sauce)
-      user = FactoryBot.create(:user)
+    describe "POST#destroy" do
+      it "user is able to delete own review" do
+        review = FactoryBot.create(:review, user: user, sauce: sauce)
+        reviews_array = sauce.reviews
 
-      sign_in user
+        post_json = {
+          id: review.id,
+          sauce_id: sauce.id
+        }
+        
+        reviews_count = sauce.reviews.length 
+        post :destroy, params: post_json, format: :json
+        returned_json = JSON.parse(response.body)
 
-      post_json = {
-        title: "",
-        rating: "",
-        heatIndex: ""
-      }
-
-      post :create, params: { review: post_json, sauce_id: ketchup.id }, format: :json
-      returned_json = JSON.parse(response.body)
-
-      expect(response.content_type).to eq("application/json")
-      expect(returned_json).to be_kind_of(Hash)
-      expect(returned_json).to_not be_kind_of(Array)
-      expect(returned_json['error']).to be_kind_of(Array)
-      expect(returned_json['error'].include?("Title can't be blank")).to eq true 
-      expect(returned_json['error'].include?("Rating is not a number")).to eq true 
-      expect(returned_json['error'].include?("Heatindex is not a number")).to eq true 
-          
+        expect(response.content_type).to eq("application/json")
+        expect(returned_json).to be_kind_of(Hash)
+        expect(returned_json).to_not be_kind_of(Array)
+        expect(returned_json['sauce']['reviews'].length).to eq(reviews_count - 1)
+      end 
     end 
   end 
 end 

--- a/spec/features/votes_controller_spec.rb
+++ b/spec/features/votes_controller_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Api::V1::VotesController, type: :controller do
 
     let(:user) { FactoryBot.create(:user) }
     let(:sauce) { FactoryBot.create(:sauce) }
-    let(:review) { FactoryBot.create(:review, sauce: sauce) }
+    let(:review) { FactoryBot.create(:review, sauce: sauce, user: user) }
 
     it "adds a new vote to a review" do
       post_json = {

--- a/spec/models/review_spec.rb
+++ b/spec/models/review_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe Review, type: :model do
   describe "#total_karma" do
     it "will return an integer of the total karma a review has based on votes" do
       sauce = FactoryBot.create(:sauce)
-      review = FactoryBot.create(:review, sauce: sauce)  
       user = FactoryBot.create(:user)
+      review = FactoryBot.create(:review, sauce: sauce, user: user)  
       vote = FactoryBot.create(:vote, user: user, review: review)
 
       expect(review.total_karma).to eq(1)


### PR DESCRIPTION
Added destroy path for api/v1/reviews_controller.rb, modified api/v1/sauces_controller.rb & vote/review_serializer.rb to match other serializer formats, added admin/user functionality to be able to delete a review in the review tile as well as updating the review form component and create path to account for votes, updated tests so they would be able to pass for reviews having to belong to a user and created tests for the reviews destroy path.

List:
-api/v1/reviews_controller.rb destroy path
-refactored votes/reviews/sauces serializer to remove include statement and match current format
-user can delete their reviews/admins can delete any reviews in ReviewTile.js
-updated ReviewForm.js and SauceShowPage.js to account for voting as it was breaking with merge of votes feature
-Created rspec test in reviews_controller_spec.rb for destroy path
-updated spec tests that didn't account for reviews belonging to user

