### PR TITLE
Add slugs to url path

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,3 +58,4 @@ gem 'webpacker', '~> 3.3'
 gem "fog-aws"
 gem 'carrierwave', '~> 2.0'
 gem "active_model_serializers"
+gem "friendly_id", '~> 5.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,6 +122,8 @@ GEM
       railties (>= 3.1.0)
       sass (>= 3.3.0)
       sprockets-es6 (>= 0.9.0)
+    friendly_id (5.4.2)
+      activerecord (>= 4.0.0)
     globalid (1.0.0)
       activesupport (>= 5.0)
     i18n (1.12.0)
@@ -302,6 +304,7 @@ DEPENDENCIES
   factory_bot
   fog-aws
   foundation-rails (~> 6.5)
+  friendly_id (~> 5.2)
   jbuilder (~> 2.5)
   jquery-rails
   launchy

--- a/app/controllers/api/v1/sauces_controller.rb
+++ b/app/controllers/api/v1/sauces_controller.rb
@@ -1,5 +1,5 @@
 class Api::V1::SaucesController < ApiController
-  def show    
-    render json: Sauce.find(params[:id])
+  def show
+    render json: Sauce.friendly.find(params[:id])
   end 
 end 

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,5 +1,5 @@
 class Api::V1::UsersController < ApiController
   def show
-    render json: User.find(params[:id])
+    render json: User.friendly.find(params[:id])
   end
 end

--- a/app/controllers/homes_controller.rb
+++ b/app/controllers/homes_controller.rb
@@ -1,4 +1,5 @@
 class HomesController < ApplicationController
   def index
+    
   end
 end

--- a/app/controllers/sauces_controller.rb
+++ b/app/controllers/sauces_controller.rb
@@ -23,11 +23,11 @@ class SaucesController < ApplicationController
   end
 
   def edit
-    @sauce = Sauce.find(params[:id])
+    @sauce = Sauce.friendly.find(params[:id])
   end
 
   def update
-    @sauce = Sauce.find(params[:id])
+    @sauce = Sauce.friendly.find(params[:id])
 
     if @sauce.update(sauce_params)
       flash[:notice] = "Sauce updated successfully"
@@ -39,7 +39,7 @@ class SaucesController < ApplicationController
   end
 
   def destroy
-    @sauce = Sauce.find(params[:id])
+    @sauce = Sauce.friendly.find(params[:id])
 
     if @sauce.destroy
       flash[:notice] = "Sauce obliterated. The sauce is lost."

--- a/app/models/sauce.rb
+++ b/app/models/sauce.rb
@@ -4,5 +4,14 @@ class Sauce < ApplicationRecord
   validates :image_url, presence: true, url: true
   validates :name, uniqueness: { scope: :brand }
 
+  extend FriendlyId
+  friendly_id :name_brand_slug, use: :slugged
+
   has_many :reviews
+
+  def name_brand_slug
+    [
+      [:name, :brand]
+    ]
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,11 +3,14 @@ class User < ApplicationRecord
 
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
-  validates :dippr_handle, presence: true, uniqueness: true
+  validates :dippr_handle, presence: true, uniqueness: true, format: { without: /\s/ }
   validates :avatar, presence: true
   validates :role, presence: true
 
   has_many :votes
+
+  extend FriendlyId
+  friendly_id :dippr_handle, use: :slugged
 
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -53,12 +53,6 @@
   <% end %>
 </div>
 
-<h3 class="page-header-text" >Cancel my account</h3>
-
-<div class="callout form-tile" >
-  <p>Can't take the heat? <%= button_to "Get out of the kitchen", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %></p>
-</div>
-
 <div class="center" >
   <%= link_to "Back", :back, class: "button secondary text-center" %>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -25,7 +25,7 @@
     <section class="top-bar-right">
       <ul class="right">
         <%- if current_user -%>
-          <li><%= link_to 'Profile', "/users/#{current_user.id}" %></li>
+          <li><%= link_to 'Profile', "/users/#{current_user.slug}" %></li>
           <li><%= link_to 'Sign Out', destroy_user_session_path, method: :delete %></li>
         <%- else -%>
           <li><%= link_to 'Sign Up', new_user_registration_path %></li>

--- a/app/views/sauces/index.html.erb
+++ b/app/views/sauces/index.html.erb
@@ -2,7 +2,7 @@
   <div class='grid-x grid-margin-x grid-margin-y'>
     <% @sauces.each do |sauce| %>
       <div class='cell small-12 medium-4'>
-        <h3><%= link_to "#{sauce.name} (#{sauce.brand})", "/sauces/#{sauce.id}" %></h3>
+        <h3><%= link_to "#{sauce.name} (#{sauce.brand})", "/sauces/#{sauce.slug}" %></h3>
         <%= image_tag sauce.image_url %>
         <% if user_signed_in? %>
           <% if current_user.admin? %>

--- a/config/initializers/friendly_id.rb
+++ b/config/initializers/friendly_id.rb
@@ -1,0 +1,107 @@
+# FriendlyId Global Configuration
+#
+# Use this to set up shared configuration options for your entire application.
+# Any of the configuration options shown here can also be applied to single
+# models by passing arguments to the `friendly_id` class method or defining
+# methods in your model.
+#
+# To learn more, check out the guide:
+#
+# http://norman.github.io/friendly_id/file.Guide.html
+
+FriendlyId.defaults do |config|
+  # ## Reserved Words
+  #
+  # Some words could conflict with Rails's routes when used as slugs, or are
+  # undesirable to allow as slugs. Edit this list as needed for your app.
+  config.use :reserved
+
+  config.reserved_words = %w(new edit index session login logout users admin
+    stylesheets assets javascripts images)
+    
+  # This adds an option to treat reserved words as conflicts rather than exceptions.
+  # When there is no good candidate, a UUID will be appended, matching the existing
+  # conflict behavior.
+
+  # config.treat_reserved_as_conflict = true
+
+  #  ## Friendly Finders
+  #
+  # Uncomment this to use friendly finders in all models. By default, if
+  # you wish to find a record by its friendly id, you must do:
+  #
+    #  MyModel.friendly.find('foo')
+  #
+  # If you uncomment this, you can do:
+  #
+  #    MyModel.find('foo')
+  #
+  # This is significantly more convenient but may not be appropriate for
+  # all applications, so you must explicity opt-in to this behavior. You can
+  # always also configure it on a per-model basis if you prefer.
+  #
+  # Something else to consider is that using the :finders addon boosts
+  # performance because it will avoid Rails-internal code that makes runtime
+  # calls to `Module.extend`.
+  #
+  # config.use :finders
+  #
+  # ## Slugs
+  #
+  # Most applications will use the :slugged module everywhere. If you wish
+  # to do so, uncomment the following line.
+  #
+  # config.use :slugged
+  #
+  # By default, FriendlyId's :slugged addon expects the slug column to be named
+  # 'slug', but you can change it if you wish.
+  #
+  # config.slug_column = 'slug'
+  #
+  # By default, slug has no size limit, but you can change it if you wish.
+  #
+  # config.slug_limit = 255
+  #
+  # When FriendlyId can not generate a unique ID from your base method, it appends
+  # a UUID, separated by a single dash. You can configure the character used as the
+  # separator. If you're upgrading from FriendlyId 4, you may wish to replace this
+  # with two dashes.
+  #
+  # config.sequence_separator = '-'
+  #
+  # Note that you must use the :slugged addon **prior** to the line which
+  # configures the sequence separator, or else FriendlyId will raise an undefined
+  # method error.
+  #
+  #  ## Tips and Tricks
+  #
+  #  ### Controlling when slugs are generated
+  #
+  # As of FriendlyId 5.0, new slugs are generated only when the slug field is
+  # nil, but if you're using a column as your base method can change this
+  # behavior by overriding the `should_generate_new_friendly_id?` method that
+  # FriendlyId adds to your model. The change below makes FriendlyId 5.0 behave
+  # more like 4.0.
+  # Note: Use(include) Slugged module in the config if using the anonymous module.
+  # If you have `friendly_id :name, use: slugged` in the model, Slugged module
+  # is included after the anonymous module defined in the initializer, so it
+  # overrides the `should_generate_new_friendly_id?` method from the anonymous module.
+  #
+  # config.use :slugged
+  # config.use Module.new {
+  #   def should_generate_new_friendly_id?
+  #     slug.blank? || <your_column_name_here>_changed?
+  #   end
+  # }
+  #
+  # FriendlyId uses Rails's `parameterize` method to generate slugs, but for
+  # languages that don't use the Roman alphabet, that's not usually sufficient.
+  # Here we use the Babosa library to transliterate Russian Cyrillic slugs to
+  # ASCII. If you use this, don't forget to add "babosa" to your Gemfile.
+  #
+  # config.use Module.new {
+  #   def normalize_friendly_id(text)
+  #     text.to_slug.normalize! :transliterations => [:russian, :latin]
+  #   end
+  # }
+end

--- a/db/migrate/20220811181446_add_slug_to_users.rb
+++ b/db/migrate/20220811181446_add_slug_to_users.rb
@@ -1,0 +1,6 @@
+class AddSlugToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :slug, :string
+    add_index :users, :slug, unique: true
+  end
+end

--- a/db/migrate/20220811181650_create_friendly_id_slugs.rb
+++ b/db/migrate/20220811181650_create_friendly_id_slugs.rb
@@ -1,0 +1,21 @@
+MIGRATION_CLASS =
+  if ActiveRecord::VERSION::MAJOR >= 5
+    ActiveRecord::Migration["#{ActiveRecord::VERSION::MAJOR}.#{ActiveRecord::VERSION::MINOR}"]
+  else
+    ActiveRecord::Migration
+  end
+
+class CreateFriendlyIdSlugs < MIGRATION_CLASS
+  def change
+    create_table :friendly_id_slugs do |t|
+      t.string   :slug,           :null => false
+      t.integer  :sluggable_id,   :null => false
+      t.string   :sluggable_type, :limit => 50
+      t.string   :scope
+      t.datetime :created_at
+    end
+    add_index :friendly_id_slugs, [:sluggable_type, :sluggable_id]
+    add_index :friendly_id_slugs, [:slug, :sluggable_type], length: { slug: 140, sluggable_type: 50 }
+    add_index :friendly_id_slugs, [:slug, :sluggable_type, :scope], length: { slug: 70, sluggable_type: 50, scope: 70 }, unique: true
+  end
+end

--- a/db/migrate/20220811191754_add_slug_to_sauces.rb
+++ b/db/migrate/20220811191754_add_slug_to_sauces.rb
@@ -1,0 +1,6 @@
+class AddSlugToSauces < ActiveRecord::Migration[5.2]
+  def change
+    add_column :sauces, :slug, :string
+    add_index :sauces, :slug, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_08_09_185413) do
+ActiveRecord::Schema.define(version: 2022_08_11_191754) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "friendly_id_slugs", force: :cascade do |t|
+    t.string "slug", null: false
+    t.integer "sluggable_id", null: false
+    t.string "sluggable_type", limit: 50
+    t.string "scope"
+    t.datetime "created_at"
+    t.index ["slug", "sluggable_type", "scope"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type_and_scope", unique: true
+    t.index ["slug", "sluggable_type"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type"
+    t.index ["sluggable_type", "sluggable_id"], name: "index_friendly_id_slugs_on_sluggable_type_and_sluggable_id"
+  end
 
   create_table "reviews", force: :cascade do |t|
     t.string "title", null: false
@@ -35,7 +46,9 @@ ActiveRecord::Schema.define(version: 2022_08_09_185413) do
     t.text "description"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "slug"
     t.index ["name", "brand"], name: "index_sauces_on_name_and_brand", unique: true
+    t.index ["slug"], name: "index_sauces_on_slug", unique: true
   end
 
   create_table "users", force: :cascade do |t|
@@ -49,9 +62,11 @@ ActiveRecord::Schema.define(version: 2022_08_09_185413) do
     t.datetime "updated_at", null: false
     t.string "avatar", null: false
     t.string "role", default: "member", null: false
+    t.string "slug"
     t.index ["dippr_handle"], name: "index_users_on_dippr_handle", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+    t.index ["slug"], name: "index_users_on_slug", unique: true
   end
 
   create_table "votes", force: :cascade do |t|


### PR DESCRIPTION
Added friendly_id gem which provides slugs for users and sauces url paths. Updated sauce and user models as well as the controllers to account for the use of slugs when finding specific objects in the database. Updated links to account for slugs on erb templates. Updated rspec feature tests to account for the slug in url path. Removed delete user button from the devise/registrations/edit.html.erb as it broke the sauce show page when a review could no longer associate a certain user.