### PR TITLE
reviews and votes were not deleted with a sauce

### DIFF
--- a/app/controllers/sauces_controller.rb
+++ b/app/controllers/sauces_controller.rb
@@ -42,6 +42,10 @@ class SaucesController < ApplicationController
     @sauce = Sauce.friendly.find(params[:id])
 
     if @sauce.destroy
+      reviews = Review.where(sauce: @sauce)
+      Vote.where(review: reviews).delete_all
+      reviews.destroy_all
+      
       flash[:notice] = "Sauce obliterated. The sauce is lost."
       redirect_to sauces_path
     else


### PR DESCRIPTION
fixed sauces_controller.rb so that all associated reviews and votes associated with said reviews are deleted when a sauce is deleted.